### PR TITLE
Isolating refinement type checker from java syntax tree traversing

### DIFF
--- a/liquidjava-umbrella/liquidjava-verifier/src/main/java/liquidjava/processor/typechecker/TypeChecker.java
+++ b/liquidjava-umbrella/liquidjava-verifier/src/main/java/liquidjava/processor/typechecker/TypeChecker.java
@@ -1,0 +1,14 @@
+package liquidjava.processor.typechecker;
+
+public class TypeChecker {
+    /*
+    * My idea is to separate typing rules to external class.
+    * This will unbind typing from traversing java syntax tree.
+    * Also, it will make adding new typing rules easier.
+    *
+    * There is already a TypeChecker class, but I want to make it closer to
+    * formalization of Liquid Java.
+    *
+    * I do not know if it is possible or useful, so I am creating this pull request to discuss.
+    * */
+}


### PR DESCRIPTION
My idea is to separate typing rules to stateless external class. 

- It will unbind typing from traversing java syntax tree.
- It will make adding new typing rules easier.
- It will bring Liquid Java implementation closer to its formalization.

I do not know if it is possible or useful, so I am creating this pull request to discuss.