### PR TITLE
32 fields updates make verification wrong in state changes

### DIFF
--- a/liquidjava-example/src/main/java/testSuite/CorrectTrafficLightRGB.java
+++ b/liquidjava-example/src/main/java/testSuite/CorrectTrafficLightRGB.java
@@ -1,0 +1,49 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+import liquidjava.specification.StateRefinement;
+import liquidjava.specification.StateSet;
+@StateSet({"green", "amber", "red"})
+public class CorrectTrafficLightRGB {
+    
+	@Refinement("r >= 0 && r <= 255") int r;
+
+	@Refinement("g >= 0 && g <= 255") int g;
+
+	@Refinement("b >= 0 && b <= 255") int b;
+
+	@StateRefinement(to = "green(this)")
+	public CorrectTrafficLightRGB() {
+		r = 255;
+		g = 0;
+		b = 0;
+	}
+
+	@StateRefinement(from = "green(this)", to = "amber(this)")
+	public void transitionToAmber() {
+		r = 255;
+		g = 120;
+		b = 0;
+	}
+
+	@StateRefinement(from = "red(this)", to = "green(this)")
+	public void transitionToGreen() {
+		r = 76;
+		g = 187;
+		b = 23;
+	}
+
+	@StateRefinement(from = "amber(this)", to = "red(this)")
+	public void transitionToRed() {
+		r = 230;
+		g = 0;
+		b = 1;
+	}
+
+
+	public static void name() {
+		CorrectTrafficLightRGB tl = new CorrectTrafficLightRGB();
+		tl.transitionToAmber();
+		tl.transitionToRed();
+	}
+}

--- a/liquidjava-example/src/main/java/testSuite/ErrorTrafficLightRGB.java
+++ b/liquidjava-example/src/main/java/testSuite/ErrorTrafficLightRGB.java
@@ -1,0 +1,49 @@
+package testSuite;
+
+import liquidjava.specification.Refinement;
+import liquidjava.specification.StateRefinement;
+import liquidjava.specification.StateSet;
+@StateSet({"green", "amber", "red"})
+public class ErrorTrafficLightRGB {
+    
+	@Refinement("r >= 0 && r <= 255") int r;
+
+	@Refinement("g >= 0 && g <= 255") int g;
+
+	@Refinement("b >= 0 && b <= 255") int b;
+
+	@StateRefinement(to = "green(this)")
+	public ErrorTrafficLightRGB() {
+		r = 255;
+		g = 0;
+		b = 0;
+	}
+
+	@StateRefinement(from = "green(this)", to = "amber(this)")
+	public void transitionToAmber() {
+		r = 255;
+		g = 120;
+		b = 0;
+	}
+
+	@StateRefinement(from = "red(this)", to = "green(this)")
+	public void transitionToGreen() {
+		r = 76;
+		g = 187;
+		b = 23;
+	}
+
+	@StateRefinement(from = "amber(this)", to = "red(this)")
+	public void transitionToRed() {
+		r = 230;
+		g = 0;
+		b = 1;
+	}
+
+
+	public static void name() {
+		ErrorTrafficLightRGB tl = new ErrorTrafficLightRGB();
+		tl.transitionToAmber();
+		tl.transitionToRed();
+	}
+}

--- a/liquidjava-verifier/src/main/java/liquidjava/api/CommandLineLauncher.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/api/CommandLineLauncher.java
@@ -18,7 +18,7 @@ public class CommandLineLauncher {
         // "../liquidjava/liquidjava-umbrella/liquidjava-example/src/main/java/liquidjava/test/project";
         String file = args.length == 0 ? allPath : args[0];
         ErrorEmitter ee = launch(file);
-        System.out.println(ee.foundError()? (ee.getFullMessage()):("Correct! Passed Verification."));
+        System.out.println(ee.foundError() ? (ee.getFullMessage()) : ("Correct! Passed Verification."));
 
     }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
@@ -135,7 +135,7 @@ public class VCChecker {
         if (firstSi != null && lastSi != null) {
             cSMT = firstSi.clone();
             lastSi.setNext(new VCImplication(expectedType));
-             printVCs(firstSi.toString(), cSMT.toConjunctions().toString(), expectedType);
+            // printVCs(firstSi.toString(), cSMT.toConjunctions().toString(), expectedType); //DEBUG: UNCOMMENT
         }
 
         return cSMT; // firstSi != null ? firstSi : new VCImplication(new Predicate());

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/VCChecker.java
@@ -100,7 +100,7 @@ public class VCChecker {
         return smtChecks(premises, et, p);
     }
 
-    private /* Predicate */ VCImplication joinPredicates(Predicate expectedType, List<RefinedVariable> mainVars,
+    private VCImplication joinPredicates(Predicate expectedType, List<RefinedVariable> mainVars,
             List<RefinedVariable> vars, HashMap<String, PlacementInCode> map) {
 
         VCImplication firstSi = null;
@@ -135,7 +135,7 @@ public class VCChecker {
         if (firstSi != null && lastSi != null) {
             cSMT = firstSi.clone();
             lastSi.setNext(new VCImplication(expectedType));
-            // printVCs(firstSi.toString(), cSMT.toConjunctions().toString(), expectedType);
+             printVCs(firstSi.toString(), cSMT.toConjunctions().toString(), expectedType);
         }
 
         return cSMT; // firstSi != null ? firstSi : new VCImplication(new Predicate());

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxStateHandler.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxStateHandler.java
@@ -48,7 +48,6 @@ public class AuxStateHandler {
         }
     }
 
-
     /**
      * Creates the list of states and adds them to the function
      *
@@ -67,7 +66,7 @@ public class AuxStateHandler {
             Map<String, CtExpression> m = an.getAllValues();
             String to = TypeCheckingUtils.getStringFromAnnotation(m.get("to"));
             ObjectState state = new ObjectState();
-            if (to != null) 
+            if (to != null)
                 state.setTo(new Predicate(to, element, tc.getErrorEmitter()));
             l.add(state);
         }
@@ -80,7 +79,7 @@ public class AuxStateHandler {
 
         Predicate[] s = { Predicate.createVar(tc.THIS) };
         Predicate c = new Predicate();
-        List<GhostFunction> sets = getDifferentSets(tc, klass);//??
+        List<GhostFunction> sets = getDifferentSets(tc, klass);// ??
         for (GhostFunction sg : sets) {
             if (sg.getReturnType().toString().equals("int")) {
                 Predicate p = Predicate.createEquals(Predicate.createInvocation(sg.getName(), s),
@@ -178,10 +177,6 @@ public class AuxStateHandler {
         }
         return state;
     }
-
-
-
-
 
     private static Predicate createStatePredicate(String value, /* RefinedFunction f */
             String targetClass, TypeChecker tc, CtElement e, boolean isTo) throws ParsingException {
@@ -448,7 +443,7 @@ public class AuxStateHandler {
                 for (String s : map.keySet()) {
                     transitionedState = transitionedState.substituteVariable(s, map.get(s));
                 }
-                transitionedState = checkOldMentions(transitionedState, instanceName, newInstanceName, tc);      
+                transitionedState = checkOldMentions(transitionedState, instanceName, newInstanceName, tc);
                 // update of stata of new instance of this#n#(whatever it was + 1)
                 addInstanceWithState(tc, name, newInstanceName, vi, transitionedState, invocation);
                 return transitionedState;
@@ -466,19 +461,20 @@ public class AuxStateHandler {
         return new Predicate();
     }
 
-
     /**
      * Method prepared to change all old vars in a predicate, however it has not been needed yet
+     * 
      * @param pred
      * @param tc
+     * 
      * @return
      */
     private static Predicate changeVarsFields(Predicate pred, TypeChecker tc) {
         Predicate noOld = pred;
         List<String> listVarsInOld = pred.getOldVariableNames();
-        for (String varInOld : listVarsInOld){
+        for (String varInOld : listVarsInOld) {
             Optional<VariableInstance> ovi = tc.getContext().getLastVariableInstance(varInOld);
-            if(ovi.isPresent())
+            if (ovi.isPresent())
                 noOld = noOld.changeOldMentions(varInOld, ovi.get().getName(), tc.getErrorEmitter());
         }
         return noOld;

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
@@ -137,31 +137,29 @@ public class Predicate {
         return new Predicate(e);
     }
 
-
-    public List<String> getOldVariableNames(){
+    public List<String> getOldVariableNames() {
         List<String> ls = new ArrayList<>();
         expressionGetOldVariableNames(this.exp, ls);
         return ls;
     }
 
-    private void expressionGetOldVariableNames(Expression exp, List<String> ls){
-        if(exp instanceof FunctionInvocation){
+    private void expressionGetOldVariableNames(Expression exp, List<String> ls) {
+        if (exp instanceof FunctionInvocation) {
             FunctionInvocation fi = (FunctionInvocation) exp;
-           if (fi.getName().equals(Utils.OLD)){
+            if (fi.getName().equals(Utils.OLD)) {
                 List<Expression> le = fi.getArgs();
-                for(Expression e: le){
-                    if (e instanceof Var) 
-                       ls.add(((Var) e).getName());
+                for (Expression e : le) {
+                    if (e instanceof Var)
+                        ls.add(((Var) e).getName());
                 }
-           }
-        } 
-        if(exp.hasChildren()){
+            }
+        }
+        if (exp.hasChildren()) {
             for (var ch : exp.getChildren())
                 expressionGetOldVariableNames(ch, ls);
-            
+
         }
     }
-    
 
     public Predicate changeStatesToRefinements(List<GhostState> ghostState, String[] toChange, ErrorEmitter ee) {
         Map<String, Expression> nameRefinementMap = new HashMap<>();

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
@@ -137,6 +137,32 @@ public class Predicate {
         return new Predicate(e);
     }
 
+
+    public List<String> getOldVariableNames(){
+        List<String> ls = new ArrayList<>();
+        expressionGetOldVariableNames(this.exp, ls);
+        return ls;
+    }
+
+    private void expressionGetOldVariableNames(Expression exp, List<String> ls){
+        if(exp instanceof FunctionInvocation){
+            FunctionInvocation fi = (FunctionInvocation) exp;
+           if (fi.getName().equals(Utils.OLD)){
+                List<Expression> le = fi.getArgs();
+                for(Expression e: le){
+                    if (e instanceof Var) 
+                       ls.add(((Var) e).getName());
+                }
+           }
+        } 
+        if(exp.hasChildren()){
+            for (var ch : exp.getChildren())
+                expressionGetOldVariableNames(ch, ls);
+            
+        }
+    }
+    
+
     public Predicate changeStatesToRefinements(List<GhostState> ghostState, String[] toChange, ErrorEmitter ee) {
         Map<String, Expression> nameRefinementMap = new HashMap<>();
         for (GhostState gs : ghostState)


### PR DESCRIPTION
Main issue: calls to `old()` for the fields were being added to the constructor state change. 
This does not make sense in the constructor since there are no old instances when an object is created. 
This issue was solved by not removing these added calls.