### PR TITLE
Qualify Ghost Names

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "configurations": [
+    {
+      "type": "java",
+      "name": "Run LiquidJava",
+      "request": "launch",
+      "mainClass": "liquidjava.api.CommandLineLauncher",
+      "projectName": "liquidjava-verifier",
+      "args": "liquidjava-example/src/main/java/test"
+    }
+  ]
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/ambiguous_state_names_correct/Door.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/ambiguous_state_names_correct/Door.java
@@ -1,0 +1,11 @@
+package testSuite.classes.ambiguous_state_names_correct;
+
+import liquidjava.specification.StateSet;
+import liquidjava.specification.StateRefinement;
+
+@StateSet({"open", "closed"})
+public class Door {
+
+    @StateRefinement(to = "open(this)")
+    public Door() { }
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/ambiguous_state_names_correct/Pipe.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/ambiguous_state_names_correct/Pipe.java
@@ -1,0 +1,11 @@
+package testSuite.classes.ambiguous_state_names_correct;
+
+import liquidjava.specification.StateSet;
+import liquidjava.specification.StateRefinement;
+
+@StateSet({"open", "closed"})
+public class Pipe {
+    
+    @StateRefinement(to = "open(this)")
+    public Pipe() { }
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/ambiguous_state_names_correct/SimpleTest.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/ambiguous_state_names_correct/SimpleTest.java
@@ -1,0 +1,14 @@
+package testSuite.classes.ambiguous_state_names_correct;
+
+import liquidjava.specification.Refinement;
+
+public class SimpleTest {
+
+    public static void main(String[] args) {
+        Door d = new Door(); // contains 'open' and 'closed' states
+        Pipe p = new Pipe(); // unrelated type with the same state names
+        requiresOpen(d); // ok iff 'open' binds to Door.open otherwise it may bind to Pipe.open and fail
+    }
+
+    public static void requiresOpen(@Refinement("open(s)") Door s) { }
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/conflicting_state_names_correct/SM1.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/conflicting_state_names_correct/SM1.java
@@ -1,0 +1,15 @@
+package testSuite.classes.conflicting_state_names_correct;
+
+import liquidjava.specification.StateRefinement;
+import liquidjava.specification.StateSet;
+
+@StateSet({"uninitialized", "initialized"})
+public class SM1 {
+
+	@StateRefinement(to="uninitialized(this)")
+	public SM1() {}
+	
+
+	@StateRefinement(from="uninitialized(this)", to="initialized(this)")
+	public void initialize() {}
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/conflicting_state_names_correct/SM2.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/conflicting_state_names_correct/SM2.java
@@ -1,0 +1,15 @@
+package testSuite.classes.conflicting_state_names_correct;
+
+import liquidjava.specification.StateRefinement;
+import liquidjava.specification.StateSet;
+
+@StateSet({"uninitialized", "initialized"})
+public class SM2 {
+
+	@StateRefinement(to="uninitialized(this)")
+	public SM2() {}
+	
+
+	@StateRefinement(from="uninitialized(this)", to="initialized(this)")
+	public void initialize() {}
+}

--- a/liquidjava-example/src/main/java/testSuite/classes/conflicting_state_names_correct/SimpleTest.java
+++ b/liquidjava-example/src/main/java/testSuite/classes/conflicting_state_names_correct/SimpleTest.java
@@ -1,0 +1,11 @@
+package testSuite.classes.conflicting_state_names_correct;
+
+class SimpleTest {
+	public static void main(String[] args) {
+		// both classes contain the same state names
+		SM1 sm1 = new SM1();
+		SM2 sm2 = new SM2();
+		sm1.initialize();
+		sm2.initialize();
+	}
+}

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/VCImplication.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/VCImplication.java
@@ -1,6 +1,7 @@
 package liquidjava.processor;
 
 import liquidjava.rj_language.Predicate;
+import liquidjava.utils.Utils;
 import spoon.reflect.reference.CtTypeReference;
 
 /**
@@ -29,7 +30,7 @@ public class VCImplication {
     public String toString() {
         if (name != null && type != null) {
             String qualType = type.getQualifiedName();
-            String simpleType = qualType.contains(".") ? qualType.substring(qualType.lastIndexOf(".") + 1) : qualType;
+            String simpleType = qualType.contains(".") ? Utils.getSimpleName(qualType) : qualType;
             return String.format("%-20s %s %s", "∀" + name + ":" + simpleType + ",", refinement.toString(),
                     next != null ? " => \n" + next.toString() : "");
         } else

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/Context.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/Context.java
@@ -335,7 +335,7 @@ public class Context {
 
     public boolean hasGhost(String name) {
         for (GhostFunction g : ghosts) {
-            if (g.getName().equals(name))
+            if (g.matches(name))
                 return true;
         }
         return false;

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/GhostFunction.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/GhostFunction.java
@@ -28,9 +28,9 @@ public class GhostFunction {
     public GhostFunction(String name, List<String> param_types, CtTypeReference<?> return_type, Factory factory,
             String prefix) {
         String klass = this.getParentClassName(prefix);
+        String type = return_type.toString().equals(klass) ? prefix : return_type.toString();
         this.name = name;
-        this.return_type = Utils.getType(return_type.toString().equals(klass) ? prefix : return_type.toString(),
-                factory);
+        this.return_type = Utils.getType(type, factory);
         this.param_types = new ArrayList<>();
         this.prefix = prefix;
         for (int i = 0; i < param_types.size(); i++) {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/GhostFunction.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/GhostFunction.java
@@ -86,7 +86,10 @@ public class GhostFunction {
         return Utils.getSimpleName(pref);
     }
 
+    // Match by fully qualified name, exact simple name or by comparing the simple name of the provided identifier
+    // This allows references written in a different class (different prefix) to still match
     public boolean matches(String name) {
-        return this.name.equals(name) || this.getQualifiedName().equals(name);
+        return this.getQualifiedName().equals(name) || this.name.equals(name)
+                || this.name.equals(Utils.getSimpleName(name));
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/GhostFunction.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/GhostFunction.java
@@ -12,40 +12,39 @@ public class GhostFunction {
     private String name;
     private List<CtTypeReference<?>> param_types;
     private CtTypeReference<?> return_type;
+    private String prefix;
 
-    private String klassName;
-
-    public GhostFunction(GhostDTO f, Factory factory, String path, String klass) {
-        name = f.getName();
-        return_type = Utils.getType(f.getReturn_type().equals(klass) ? path : f.getReturn_type(), factory);
-        param_types = new ArrayList<>();
+    public GhostFunction(GhostDTO f, Factory factory, String prefix) {
+        String klass = this.getParentClassName(prefix);
+        this.name = f.getName();
+        this.return_type = Utils.getType(f.getReturn_type().equals(klass) ? prefix : f.getReturn_type(), factory);
+        this.param_types = new ArrayList<>();
+        this.prefix = prefix;
         for (String t : f.getParam_types()) {
-            param_types.add(Utils.getType(t.equals(klass) ? path : t, factory));
+            this.param_types.add(Utils.getType(t.equals(klass) ? prefix : t, factory));
         }
     }
 
     public GhostFunction(String name, List<String> param_types, CtTypeReference<?> return_type, Factory factory,
-            String path, String klass) {
+            String prefix) {
+        String klass = this.getParentClassName(prefix);
         this.name = name;
-        this.return_type = Utils.getType(return_type.toString().equals(klass) ? path : return_type.toString(), factory);
+        this.return_type = Utils.getType(return_type.toString().equals(klass) ? prefix : return_type.toString(),
+                factory);
         this.param_types = new ArrayList<>();
+        this.prefix = prefix;
         for (int i = 0; i < param_types.size(); i++) {
             String mType = param_types.get(i).toString();
-            this.param_types.add(Utils.getType(mType.equals(klass) ? path : mType, factory));
+            this.param_types.add(Utils.getType(mType.equals(klass) ? prefix : mType, factory));
         }
-        this.klassName = klass;
     }
 
-    protected GhostFunction(String name, List<CtTypeReference<?>> list, CtTypeReference<?> return_type, String klass) {
+    protected GhostFunction(String name, List<CtTypeReference<?>> list, CtTypeReference<?> return_type, String prefix) {
         this.name = name;
         this.return_type = return_type;
         this.param_types = new ArrayList<>();
         this.param_types = list;
-        this.klassName = klass;
-    }
-
-    public String getName() {
-        return name;
+        this.prefix = prefix;
     }
 
     public CtTypeReference<?> getReturnType() {
@@ -67,7 +66,27 @@ public class GhostFunction {
         return sb.toString();
     }
 
+    public String getName() {
+        return name;
+    }
+
+    public String getPrefix() {
+        return prefix;
+    }
+
+    public String getQualifiedName() {
+        return Utils.qualifyName(prefix, name);
+    }
+
     public String getParentClassName() {
-        return klassName;
+        return getParentClassName(prefix);
+    }
+
+    private String getParentClassName(String pref) {
+        return Utils.getSimpleName(pref);
+    }
+
+    public boolean matches(String name) {
+        return this.name.equals(name) || this.getQualifiedName().equals(name);
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/GhostParentState.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/GhostParentState.java
@@ -9,9 +9,8 @@ public class GhostParentState extends GhostFunction {
 
     private ArrayList<GhostState> states;
 
-    public GhostParentState(String name, List<String> params, CtTypeReference<?> ret, Factory factory,
-            String qualifiedName, String simpleName) {
-        super(name, params, ret, factory, qualifiedName, simpleName);
+    public GhostParentState(String name, List<String> params, CtTypeReference<?> ret, Factory factory, String prefix) {
+        super(name, params, ret, factory, prefix);
         states = new ArrayList<>();
     }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/context/GhostState.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/context/GhostState.java
@@ -9,8 +9,8 @@ public class GhostState extends GhostFunction {
     private GhostFunction parent;
     private Predicate refinement;
 
-    public GhostState(String name, List<CtTypeReference<?>> list, CtTypeReference<?> return_type, String klass) {
-        super(name, list, return_type, klass);
+    public GhostState(String name, List<CtTypeReference<?>> list, CtTypeReference<?> return_type, String prefix) {
+        super(name, list, return_type, prefix);
     }
 
     public void setGhostParent(GhostFunction parent) {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/facade/AliasDTO.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/facade/AliasDTO.java
@@ -26,7 +26,7 @@ public class AliasDTO {
         this.name = name2;
         this.varTypes = varTypes2;
         this.varNames = varNames2;
-        this.expression = RefinementsParser.createAST(ref);
+        this.expression = RefinementsParser.createAST(ref, null); // is the parent class needed here?
     }
 
     public String getName() {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/facade/AliasDTO.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/facade/AliasDTO.java
@@ -12,6 +12,7 @@ public class AliasDTO {
     private List<String> varTypes;
     private List<String> varNames;
     private Expression expression;
+    private String ref;
 
     public AliasDTO(String name, List<CtTypeReference<?>> varTypes, List<String> varNames, Expression expression) {
         super();
@@ -26,7 +27,15 @@ public class AliasDTO {
         this.name = name2;
         this.varTypes = varTypes2;
         this.varNames = varNames2;
-        this.expression = RefinementsParser.createAST(ref, null); // is the parent class needed here?
+        this.ref = ref;
+    }
+
+    // Parse the alias expression using the given the prefix to ensure ghost names are qualified consistently with
+    // where the alias is declared or used
+    public void parse(String prefix) throws ParsingException {
+        if (ref != null) {
+            this.expression = RefinementsParser.createAST(ref, prefix);
+        }
     }
 
     public String getName() {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/ExternalRefinementTypeChecker.java
@@ -12,6 +12,7 @@ import liquidjava.processor.refinement_checker.general_checkers.MethodsFunctions
 import liquidjava.rj_language.Predicate;
 import liquidjava.rj_language.parsing.ParsingException;
 import liquidjava.rj_language.parsing.RefinementsParser;
+import liquidjava.utils.Utils;
 import spoon.reflect.declaration.CtClass;
 import spoon.reflect.declaration.CtElement;
 import spoon.reflect.declaration.CtField;
@@ -40,7 +41,7 @@ public class ExternalRefinementTypeChecker extends TypeChecker {
 
         Optional<String> externalRefinements = getExternalRefinement(intrface);
         if (externalRefinements.isPresent()) {
-            prefix = externalRefinements.get();
+            this.prefix = externalRefinements.get();
             try {
                 getRefinementFromAnnotation(intrface);
             } catch (ParsingException e) {
@@ -89,9 +90,7 @@ public class ExternalRefinementTypeChecker extends TypeChecker {
             // RefinementParser.parseFunctionDecl(value);
             GhostDTO f = RefinementsParser.getGhostDeclaration(value);
             if (f != null && element.getParent() instanceof CtInterface<?>) {
-                String[] a = prefix.split("\\.");
-                String d = a[a.length - 1];
-                GhostFunction gh = new GhostFunction(f, factory, prefix, d);
+                GhostFunction gh = new GhostFunction(f, factory, prefix);
                 context.addGhostFunction(gh);
             }
 
@@ -104,13 +103,12 @@ public class ExternalRefinementTypeChecker extends TypeChecker {
 
     @Override
     protected Optional<GhostFunction> createStateGhost(int order, CtElement element) {
-        String[] a = prefix.split("\\.");
-        String klass = a[a.length - 1];
+        String klass = Utils.getSimpleName(prefix);
         if (klass != null) {
             CtTypeReference<?> ret = factory.Type().INTEGER_PRIMITIVE;
             List<String> params = Arrays.asList(klass);
-            GhostFunction gh = new GhostFunction(String.format("%s_state%d", klass.toLowerCase(), order), params, ret,
-                    factory, prefix, klass);
+            String name = String.format("state%d", order);
+            GhostFunction gh = new GhostFunction(name, params, ret, factory, prefix);
             return Optional.of(gh);
         }
         return Optional.empty();
@@ -123,7 +121,6 @@ public class ExternalRefinementTypeChecker extends TypeChecker {
 
     @Override
     protected String getSimpleClassName(CtElement elem) {
-        String[] a = prefix.split("\\.");
-        return a[a.length - 1];
+        return Utils.getSimpleName(prefix);
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
@@ -232,6 +232,7 @@ public abstract class TypeChecker extends CtScanner {
                     path = ((CtInterface<?>) element).getQualifiedName();
                 }
                 if (klass != null && path != null) {
+                    a.parse(path);
                     AliasWrapper aw = new AliasWrapper(a, factory, WILD_VAR, context, klass, path);
                     context.addAlias(aw);
                 }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/TypeChecker.java
@@ -128,7 +128,7 @@ public abstract class TypeChecker extends CtScanner {
                 CtLiteral<String> s = (CtLiteral<String>) ce;
                 String f = s.getValue();
                 GhostState gs = new GhostState(f, g.getParametersTypes(), factory.Type().BOOLEAN_PRIMITIVE,
-                        g.getParentClassName());
+                        g.getPrefix());
                 gs.setGhostParent(g);
                 gs.setRefinement(
                         /* new OperationPredicate(new InvocationPredicate(f, THIS), "<-->", */
@@ -194,9 +194,8 @@ public abstract class TypeChecker extends CtScanner {
         if (klass != null) {
             CtTypeReference<?> ret = factory.Type().INTEGER_PRIMITIVE;
             List<String> params = Arrays.asList(klass.getSimpleName());
-            GhostFunction gh = new GhostFunction(
-                    String.format("%s_state%d", klass.getSimpleName().toLowerCase(), order), params, ret, factory,
-                    klass.getQualifiedName(), klass.getSimpleName());
+            String name = String.format("state%d", order);
+            GhostFunction gh = new GhostFunction(name, params, ret, factory, klass.getQualifiedName());
             return Optional.of(gh);
         }
         return Optional.empty();
@@ -207,7 +206,7 @@ public abstract class TypeChecker extends CtScanner {
             GhostDTO f = RefinementsParser.getGhostDeclaration(value);
             if (f != null && element.getParent() instanceof CtClass<?>) {
                 CtClass<?> klass = (CtClass<?>) element.getParent();
-                GhostFunction gh = new GhostFunction(f, factory, klass.getQualifiedName(), klass.getSimpleName());
+                GhostFunction gh = new GhostFunction(f, factory, klass.getQualifiedName());
                 context.addGhostFunction(gh);
             }
         } catch (ParsingException e) {

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/MethodsFunctionsChecker.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/general_checkers/MethodsFunctionsChecker.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import liquidjava.processor.context.Context;
 import liquidjava.processor.context.RefinedFunction;
 import liquidjava.processor.context.RefinedVariable;
@@ -16,6 +17,7 @@ import liquidjava.processor.refinement_checker.object_checkers.AuxHierarchyRefin
 import liquidjava.processor.refinement_checker.object_checkers.AuxStateHandler;
 import liquidjava.rj_language.Predicate;
 import liquidjava.rj_language.parsing.ParsingException;
+import liquidjava.utils.Utils;
 import spoon.reflect.code.CtConstructorCall;
 import spoon.reflect.code.CtExpression;
 import spoon.reflect.code.CtFieldRead;
@@ -90,7 +92,8 @@ public class MethodsFunctionsChecker {
         rtc.getContext().addFunctionToContext(f);
 
         auxGetMethodRefinements(method, f);
-        AuxStateHandler.handleMethodState(method, f, rtc);
+        String prefix = method.getDeclaringType().getQualifiedName();
+        AuxStateHandler.handleMethodState(method, f, rtc, prefix);
 
         if (klass != null)
             AuxHierarchyRefinememtsPassage.checkFunctionInSupertypes(klass, method, f, rtc);
@@ -98,8 +101,7 @@ public class MethodsFunctionsChecker {
 
     public <R> void getMethodRefinements(CtMethod<R> method, String prefix) throws ParsingException {
         String constructorName = "<init>";
-        String[] pac = prefix.split("\\.");
-        String k = pac[pac.length - 1];
+        String k = Utils.getSimpleName(prefix);
 
         String functionName = String.format("%s.%s", prefix, method.getSimpleName());
         if (k.equals(method.getSimpleName())) { // is a constructor
@@ -114,7 +116,7 @@ public class MethodsFunctionsChecker {
         rtc.getContext().addFunctionToContext(f);
         auxGetMethodRefinements(method, f);
 
-        AuxStateHandler.handleMethodState(method, f, rtc);
+        AuxStateHandler.handleMethodState(method, f, rtc, prefix);
         if (functionName.equals(constructorName) && !f.hasStateChange()) {
             AuxStateHandler.setDefaultState(f, rtc);
         }

--- a/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxStateHandler.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/processor/refinement_checker/object_checkers/AuxStateHandler.java
@@ -154,12 +154,10 @@ public class AuxStateHandler {
         String from = TypeCheckingUtils.getStringFromAnnotation(m.get("from"));
         String to = TypeCheckingUtils.getStringFromAnnotation(m.get("to"));
         ObjectState state = new ObjectState();
-        if (from != null) // has From
-        {
+        if (from != null) { // has From
             state.setFrom(createStatePredicate(from, f.getTargetClass(), tc, e, false, prefix));
         }
-        if (to != null) // has To
-        {
+        if (to != null) { // has To
             state.setTo(createStatePredicate(to, f.getTargetClass(), tc, e, true, prefix));
         }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
@@ -185,6 +185,9 @@ public class Predicate {
                 String name = gs.getQualifiedName();
                 Expression exp = innerParse(gs.getRefinement().toString(), ee, gs.getPrefix());
                 nameRefinementMap.put(name, exp);
+                // Also allow simple name lookup to enable hierarchy matching
+                String simple = Utils.getSimpleName(name);
+                nameRefinementMap.putIfAbsent(simple, exp);
             }
         }
         Expression e = exp.substituteState(nameRefinementMap, toChange);

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/Predicate.java
@@ -25,10 +25,8 @@ import liquidjava.rj_language.parsing.ParsingException;
 import liquidjava.rj_language.parsing.RefinementsParser;
 import liquidjava.utils.Utils;
 import spoon.reflect.declaration.CtElement;
-import spoon.reflect.declaration.CtInterface;
 import spoon.reflect.declaration.CtType;
 import spoon.reflect.factory.Factory;
-import spoon.reflect.reference.CtTypeReference;
 
 /**
  * Acts as a wrapper for Expression AST
@@ -38,7 +36,7 @@ import spoon.reflect.reference.CtTypeReference;
 public class Predicate {
 
     protected Expression exp;
-    protected String parentClass;
+    protected String prefix;
 
     /** Create a predicate with the expression true */
     public Predicate() {
@@ -69,7 +67,7 @@ public class Predicate {
      * @throws ParsingException
      */
     public Predicate(String ref, CtElement element, ErrorEmitter e, String prefix) throws ParsingException {
-        this.parentClass = prefix;
+        this.prefix = prefix;
         exp = parse(ref, element, e);
         if (e.foundError()) {
             return;
@@ -86,16 +84,16 @@ public class Predicate {
 
     protected Expression parse(String ref, CtElement element, ErrorEmitter e) throws ParsingException {
         try {
-            return RefinementsParser.createAST(ref, parentClass);
+            return RefinementsParser.createAST(ref, prefix);
         } catch (ParsingException e1) {
             ErrorHandler.printSyntaxError(e1.getMessage(), ref, element, e);
             throw e1;
         }
     }
 
-    protected Expression innerParse(String ref, ErrorEmitter e, String parentClass) {
+    protected Expression innerParse(String ref, ErrorEmitter e, String prefix) {
         try {
-            return RefinementsParser.createAST(ref, parentClass);
+            return RefinementsParser.createAST(ref, prefix);
         } catch (ParsingException e1) {
             ErrorHandler.printSyntaxError(e1.getMessage(), ref, e);
         }

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/Expression.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/Expression.java
@@ -8,6 +8,7 @@ import liquidjava.processor.context.Context;
 import liquidjava.processor.facade.AliasDTO;
 import liquidjava.rj_language.ast.typing.TypeInfer;
 import liquidjava.smt.TranslatorToZ3;
+import liquidjava.utils.Utils;
 import spoon.reflect.factory.Factory;
 
 public abstract class Expression {
@@ -98,10 +99,13 @@ public abstract class Expression {
         Expression e = clone();
         if (this instanceof FunctionInvocation) {
             FunctionInvocation fi = (FunctionInvocation) this;
-            if (subMap.containsKey(fi.name) && fi.children.size() == 1 && fi.children.get(0) instanceof Var) { // object
+            String key = fi.name;
+            String simple = Utils.getSimpleName(key);
+            boolean has = subMap.containsKey(key) || subMap.containsKey(simple);
+            if (has && fi.children.size() == 1 && fi.children.get(0) instanceof Var) { // object
                 // state
                 Var v = (Var) fi.children.get(0);
-                Expression sub = subMap.get(fi.name).clone();
+                Expression sub = (subMap.containsKey(key) ? subMap.get(key) : subMap.get(simple)).clone();
                 for (String s : toChange) {
                     sub = sub.substitute(new Var(s), v);
                 }
@@ -119,10 +123,13 @@ public abstract class Expression {
                 Expression exp = children.get(i);
                 if (exp instanceof FunctionInvocation) {
                     FunctionInvocation fi = (FunctionInvocation) exp;
-                    if (subMap.containsKey(fi.name) && fi.children.size() == 1 && fi.children.get(0) instanceof Var) { // object
+                    String key = fi.name;
+                    String simple = Utils.getSimpleName(key);
+                    boolean has = subMap.containsKey(key) || subMap.containsKey(simple);
+                    if (has && fi.children.size() == 1 && fi.children.get(0) instanceof Var) { // object
                         // state
                         Var v = (Var) fi.children.get(0);
-                        Expression sub = subMap.get(fi.name).clone();
+                        Expression sub = (subMap.containsKey(key) ? subMap.get(key) : subMap.get(simple)).clone();
                         for (String s : toChange) {
                             sub = sub.substitute(new Var(s), v);
                         }

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/FunctionInvocation.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/FunctionInvocation.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import liquidjava.smt.TranslatorToZ3;
+import liquidjava.utils.Utils;
 
 public class FunctionInvocation extends Expression {
     String name;
@@ -50,8 +51,18 @@ public class FunctionInvocation extends Expression {
 
     @Override
     public void getStateInvocations(List<String> toAdd, List<String> all) {
-        if (!toAdd.contains(name) && all.contains(name))
-            toAdd.add(name);
+        if (!toAdd.contains(name)) {
+            // Accept either qualified or simple name
+            if (all.contains(name)) {
+                toAdd.add(name);
+            } else {
+                String simple = Utils.getSimpleName(name);
+                boolean matchesSimple = all.stream()
+                        .anyMatch(s -> s.equals(simple) || (s.contains(".") && Utils.getSimpleName(s).equals(simple)));
+                if (matchesSimple)
+                    toAdd.add(name);
+            }
+        }
         for (Expression e : getArgs())
             e.getStateInvocations(toAdd, all);
     }

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/typing/TypeInfer.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/ast/typing/TypeInfer.java
@@ -95,7 +95,7 @@ public class TypeInfer {
     }
 
     private static Optional<CtTypeReference<?>> functionType(Context ctx, Factory factory, FunctionInvocation e) {
-        Optional<GhostFunction> gh = ctx.getGhosts().stream().filter(g -> g.getName().equals(e.getName())).findAny();
+        Optional<GhostFunction> gh = ctx.getGhosts().stream().filter(g -> g.matches(e.getName())).findAny();
         return gh.map(i -> i.getReturnType());
     }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/parsing/RefinementsParser.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/parsing/RefinementsParser.java
@@ -17,9 +17,9 @@ import rj.grammar.RJParser;
 
 public class RefinementsParser {
 
-    public static Expression createAST(String toParse, String parentClass) throws ParsingException {
+    public static Expression createAST(String toParse, String prefix) throws ParsingException {
         ParseTree pt = compile(toParse);
-        CreateASTVisitor visitor = new CreateASTVisitor(parentClass);
+        CreateASTVisitor visitor = new CreateASTVisitor(prefix);
         return visitor.create(pt);
     }
 

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/parsing/RefinementsParser.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/parsing/RefinementsParser.java
@@ -17,9 +17,10 @@ import rj.grammar.RJParser;
 
 public class RefinementsParser {
 
-    public static Expression createAST(String toParse) throws ParsingException {
+    public static Expression createAST(String toParse, String parentClass) throws ParsingException {
         ParseTree pt = compile(toParse);
-        return CreateASTVisitor.create(pt);
+        CreateASTVisitor visitor = new CreateASTVisitor(parentClass);
+        return visitor.create(pt);
     }
 
     /**

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/visitors/CreateASTVisitor.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/visitors/CreateASTVisitor.java
@@ -57,10 +57,10 @@ import rj.grammar.RJParser.VarContext;
  */
 public class CreateASTVisitor {
 
-    String parentClass;
+    String prefix;
 
-    public CreateASTVisitor(String parentClass) {
-        this.parentClass = parentClass;
+    public CreateASTVisitor(String prefix) {
+        this.prefix = prefix;
     }
 
     public Expression create(ParseTree rc) {
@@ -162,7 +162,7 @@ public class CreateASTVisitor {
         if (rc.ghostCall() != null) {
             GhostCallContext gc = rc.ghostCall();
             List<Expression> le = getArgs(gc.args());
-            String name = Utils.qualifyName(parentClass, gc.ID().getText());
+            String name = Utils.qualifyName(prefix, gc.ID().getText());
             return new FunctionInvocation(name, le);
         } else {
             AliasCallContext gc = rc.aliasCall();

--- a/liquidjava-verifier/src/main/java/liquidjava/rj_language/visitors/CreateASTVisitor.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/rj_language/visitors/CreateASTVisitor.java
@@ -14,6 +14,8 @@ import liquidjava.rj_language.ast.LiteralReal;
 import liquidjava.rj_language.ast.LiteralString;
 import liquidjava.rj_language.ast.UnaryExpression;
 import liquidjava.rj_language.ast.Var;
+import liquidjava.utils.Utils;
+
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.apache.commons.lang3.NotImplementedException;
 import rj.grammar.RJParser.AliasCallContext;
@@ -55,7 +57,13 @@ import rj.grammar.RJParser.VarContext;
  */
 public class CreateASTVisitor {
 
-    public static Expression create(ParseTree rc) {
+    String parentClass;
+
+    public CreateASTVisitor(String parentClass) {
+        this.parentClass = parentClass;
+    }
+
+    public Expression create(ParseTree rc) {
         if (rc instanceof ProgContext)
             return progCreate((ProgContext) rc);
         else if (rc instanceof StartContext)
@@ -76,20 +84,20 @@ public class CreateASTVisitor {
         return null;
     }
 
-    private static Expression progCreate(ProgContext rc) {
+    private Expression progCreate(ProgContext rc) {
         if (rc.start() != null)
             return create(rc.start());
         return null;
     }
 
-    private static Expression startCreate(ParseTree rc) {
+    private Expression startCreate(ParseTree rc) {
         if (rc instanceof StartPredContext)
             return create(((StartPredContext) rc).pred());
         // alias and ghost do not have evaluation
         return null;
     }
 
-    private static Expression predCreate(ParseTree rc) {
+    private Expression predCreate(ParseTree rc) {
         if (rc instanceof PredGroupContext)
             return new GroupExpression(create(((PredGroupContext) rc).pred()));
         else if (rc instanceof PredNegateContext)
@@ -104,7 +112,7 @@ public class CreateASTVisitor {
             return create(((PredExpContext) rc).exp());
     }
 
-    private static Expression expCreate(ParseTree rc) {
+    private Expression expCreate(ParseTree rc) {
         if (rc instanceof ExpGroupContext)
             return new GroupExpression(create(((ExpGroupContext) rc).exp()));
         else if (rc instanceof ExpBoolContext) {
@@ -116,7 +124,7 @@ public class CreateASTVisitor {
         }
     }
 
-    private static Expression operandCreate(ParseTree rc) {
+    private Expression operandCreate(ParseTree rc) {
         if (rc instanceof OpLiteralContext)
             return create(((OpLiteralContext) rc).literalExpression());
         else if (rc instanceof OpArithContext)
@@ -135,7 +143,7 @@ public class CreateASTVisitor {
         return null;
     }
 
-    private static Expression literalExpressionCreate(ParseTree rc) {
+    private Expression literalExpressionCreate(ParseTree rc) {
         if (rc instanceof LitGroupContext)
             return new GroupExpression(create(((LitGroupContext) rc).literalExpression()));
         else if (rc instanceof LitContext)
@@ -150,11 +158,12 @@ public class CreateASTVisitor {
         }
     }
 
-    private static Expression functionCallCreate(FunctionCallContext rc) {
+    private Expression functionCallCreate(FunctionCallContext rc) {
         if (rc.ghostCall() != null) {
             GhostCallContext gc = rc.ghostCall();
             List<Expression> le = getArgs(gc.args());
-            return new FunctionInvocation(gc.ID().getText(), le);
+            String name = Utils.qualifyName(parentClass, gc.ID().getText());
+            return new FunctionInvocation(name, le);
         } else {
             AliasCallContext gc = rc.aliasCall();
             List<Expression> le = getArgs(gc.args());
@@ -162,7 +171,7 @@ public class CreateASTVisitor {
         }
     }
 
-    private static List<Expression> getArgs(ArgsContext args) {
+    private List<Expression> getArgs(ArgsContext args) {
         List<Expression> le = new ArrayList<>();
         if (args != null)
             for (PredContext oc : args.pred()) {
@@ -171,7 +180,7 @@ public class CreateASTVisitor {
         return le;
     }
 
-    private static Expression literalCreate(LiteralContext literalContext) {
+    private Expression literalCreate(LiteralContext literalContext) {
         if (literalContext.BOOL() != null)
             return new LiteralBoolean(literalContext.BOOL().getText());
         else if (literalContext.STRING() != null)

--- a/liquidjava-verifier/src/main/java/liquidjava/smt/TranslatorContextToZ3.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/smt/TranslatorContextToZ3.java
@@ -127,7 +127,8 @@ public class TranslatorContextToZ3 {
     private static void addGhostFunction(Context z3, GhostFunction gh, Map<String, FuncDecl<?>> funcTranslation) {
         List<CtTypeReference<?>> paramTypes = gh.getParametersTypes();
         Sort ret = getSort(z3, gh.getReturnType().toString());
-        Sort[] d = paramTypes.stream().map(t -> t.toString()).map(t -> getSort(z3, t)).toArray(Sort[]::new);
-        funcTranslation.put(gh.getName(), z3.mkFuncDecl(gh.getName(), d, ret));
+        Sort[] domain = paramTypes.stream().map(t -> t.toString()).map(t -> getSort(z3, t)).toArray(Sort[]::new);
+        String name = gh.getQualifiedName();
+        funcTranslation.put(name, z3.mkFuncDecl(name, domain, ret));
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/smt/TranslatorToZ3.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/smt/TranslatorToZ3.java
@@ -17,6 +17,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import liquidjava.processor.context.AliasWrapper;
+import liquidjava.utils.Utils;
+
 import org.apache.commons.lang3.NotImplementedException;
 
 public class TranslatorToZ3 implements AutoCloseable {
@@ -90,11 +92,10 @@ public class TranslatorToZ3 implements AutoCloseable {
             return makeStore(name, params);
         if (name.equals("getFromIndex"))
             return makeSelect(name, params);
-
-        if (!funcTranslation.containsKey(name))
-            throw new NotFoundError("Function '" + name + "' not found");
-
         FuncDecl<?> fd = funcTranslation.get(name);
+        if (fd == null)
+            fd = resolveFunctionDeclFallback(name, params);
+
         Sort[] s = fd.getDomain();
         for (int i = 0; i < s.length; i++) {
             Expr<?> param = params[i];
@@ -112,6 +113,37 @@ public class TranslatorToZ3 implements AutoCloseable {
         }
 
         return z3.mkApp(fd, params);
+    }
+
+    /**
+     * Fallback resolver for function declarations when an exact qualified name lookup fails. Tries to match by simple
+     * name and number of parameters, preferring an exact qualified-name match if found among candidates; otherwise
+     * returns the first compatible candidate and relies on later coercion via var supertypes.
+     */
+    private FuncDecl<?> resolveFunctionDeclFallback(String name, Expr<?>[] params) throws Exception {
+        String simple = Utils.getSimpleName(name);
+        FuncDecl<?> candidate = null;
+        for (Map.Entry<String, FuncDecl<?>> entry : funcTranslation.entrySet()) {
+            String k = entry.getKey();
+            String simpleK = Utils.getSimpleName(k);
+            if (simple.equals(simpleK)) {
+                FuncDecl<?> fTry = entry.getValue();
+                Sort[] dom = fTry.getDomain();
+                if (dom.length == params.length) {
+                    // Prefer exact qualified name match if available
+                    if (k.equals(name)) {
+                        candidate = fTry;
+                        break;
+                    }
+                    // Otherwise first compatible match
+                    candidate = fTry;
+                }
+            }
+        }
+        if (candidate != null) {
+            return candidate;
+        }
+        throw new NotFoundError("Function '" + name + "' not found");
     }
 
     @SuppressWarnings({ "unchecked", "rawtypes" })

--- a/liquidjava-verifier/src/main/java/liquidjava/utils/Utils.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/utils/Utils.java
@@ -1,5 +1,7 @@
 package liquidjava.utils;
 
+import java.util.Set;
+
 import spoon.reflect.factory.Factory;
 import spoon.reflect.reference.CtTypeReference;
 
@@ -34,6 +36,8 @@ public class Utils {
     public static final String LONG = "long";
     public static final String FLOAT = "float";
 
+    private static final Set<String> defaultNames = Set.of("old", "length", "addToIndex", "getFromIndex");
+
     public static CtTypeReference<?> getType(String type, Factory factory) {
         // TODO complete
         switch (type) {
@@ -53,5 +57,16 @@ public class Utils {
             // return factory.Type().OBJECT;
             return factory.createReference(type);
         }
+    }
+
+    public static String getSimpleName(String qualifiedName) {
+        String[] parts = qualifiedName.split("\\.");
+        return parts[parts.length - 1];
+    }
+
+    public static String qualifyName(String prefix, String name) {
+        if (defaultNames.contains(name))
+            return name;
+        return String.format("%s.%s", prefix, name);
     }
 }

--- a/liquidjava-verifier/src/main/java/liquidjava/utils/Utils.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/utils/Utils.java
@@ -59,9 +59,8 @@ public class Utils {
         }
     }
 
-    public static String getSimpleName(String qualifiedName) {
-        String[] parts = qualifiedName.split("\\.");
-        return parts[parts.length - 1];
+    public static String getSimpleName(String name) {
+        return name.contains(".") ? name.substring(name.lastIndexOf('.') + 1) : name;
     }
 
     public static String qualifyName(String prefix, String name) {

--- a/liquidjava-verifier/src/main/java/liquidjava/utils/Utils.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/utils/Utils.java
@@ -36,7 +36,7 @@ public class Utils {
     public static final String LONG = "long";
     public static final String FLOAT = "float";
 
-    private static final Set<String> defaultNames = Set.of("old", "length", "addToIndex", "getFromIndex");
+    private static final Set<String> DEFAULT_NAMES = Set.of("old", "length", "addToIndex", "getFromIndex");
 
     public static CtTypeReference<?> getType(String type, Factory factory) {
         // TODO complete
@@ -65,8 +65,8 @@ public class Utils {
     }
 
     public static String qualifyName(String prefix, String name) {
-        if (defaultNames.contains(name))
-            return name;
+        if (DEFAULT_NAMES.contains(name))
+            return name; // dont qualify
         return String.format("%s.%s", prefix, name);
     }
 }


### PR DESCRIPTION
### Summary
Added qualified names so ghosts/states with the same name from different classes don't conflict with each other.

### Motivation
Different classes frequently reuse ghost/state names (e.g., `open`, `close`, `size`). Without qualification, simple name lookups collide, causing wrong substitutions and sort mismatches in the SMT solver.

### Key Changes

- **Qualified names:** ghosts/states are stored and looked up with their declaring class prefix (e.g., `java.util.ArrayList.size`, `com.example.SM1.initialized`).
- **Keep built-ins unqualified:** `old`, `length`, `addToIndex` and `getFromIndex`.
- **Safe resolution:** `VCChecker` filters candidate ghosts/states to those whose prefix matches the types (and supertypes) of variables in the current VC, preventing unrelated classes with the same simple name from matching (removes ambiguity).
- **Hierarchy-aware:** added functionality in `AuxStateHandler` so subclasses can reference superclass states (`Bus.close` -> `Car.close`)
- **Simple name fallback:** added fallback in `TranslatorToZ3`to match by simple name and number of parameters, preferring exact qualified names.

**Note:** The last three points were implemented using an AI coding agent (GPT-5).
