### PR TITLE
Check If Path Exists in CommandLineLauncher

### DIFF
--- a/liquidjava-verifier/src/main/java/liquidjava/api/CommandLineLauncher.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/api/CommandLineLauncher.java
@@ -18,20 +18,29 @@ public class CommandLineLauncher {
         // In eclipse only needed this:"../liquidjava-example/src/main/java/"
         // In VSCode needs:
         // "../liquidjava/liquidjava-umbrella/liquidjava-example/src/main/java/liquidjava/test/project";
-        String file = args.length == 0 ? allPath : args[0];
-        ErrorEmitter ee = launch(file);
+        String path = args.length == 0 ? allPath : args[0];
+        ErrorEmitter ee = launch(path);
         System.out.println(ee.foundError() ? (ee.getFullMessage()) : ("Correct! Passed Verification."));
     }
 
-    public static ErrorEmitter launchTest(String file) {
-        ErrorEmitter ee = launch(file);
+    public static ErrorEmitter launchTest(String path) {
+        ErrorEmitter ee = launch(path);
         return ee;
     }
 
-    public static ErrorEmitter launch(String file) {
-        System.out.println("Running LiquidJava on: " + file);
+    public static ErrorEmitter launch(String path) {
+        System.out.println("Running LiquidJava on: " + path);
+        ErrorEmitter ee = new ErrorEmitter();
+
+        // check if the path exists
+        File f = new File(path);
+        if (!f.exists()) {
+            ee.addError("Path not found", "The path " + path + " does not exist", 1);
+            return ee;
+        }
+
         Launcher launcher = new Launcher();
-        launcher.addInputResource(file);
+        launcher.addInputResource(path);
         launcher.getEnvironment().setNoClasspath(true);
 
         // Get the current classpath from the system
@@ -48,7 +57,6 @@ public class CommandLineLauncher {
         final Factory factory = launcher.getFactory();
         final ProcessingManager processingManager = new QueueProcessingManager(factory);
 
-        ErrorEmitter ee = new ErrorEmitter();
         final RefinementProcessor processor = new RefinementProcessor(factory, ee);
         processingManager.addProcessor(processor);
 

--- a/liquidjava-verifier/src/main/java/liquidjava/errors/ErrorEmitter.java
+++ b/liquidjava-verifier/src/main/java/liquidjava/errors/ErrorEmitter.java
@@ -56,7 +56,7 @@ public class ErrorEmitter {
     }
 
     public boolean foundError() {
-        return fullMessage != null && position != null;
+        return fullMessage != null;
     }
 
     public String getTitleMessage() {


### PR DESCRIPTION
Added a check to return an error and skip the verification if the path provided as program argument does not exist, instead of saying `"Correct! Passed Verification!"` which can be misleading if the user accidentally provides a wrong path.